### PR TITLE
Adding transformers, exporting MonadTrans and MonadIO

### DIFF
--- a/p.cabal
+++ b/p.cabal
@@ -15,6 +15,7 @@ description:           A set of standard preludes for Ambiata projects. \
 library
   build-depends:
                           base                        >= 4.6        && < 5
+                        , bifunctors                  >= 4.2        && <= 5
                         , either                      >= 4.3        && < 4.5
                         , semigroups                  == 0.16.*
                         , transformers                >= 0.3        && < 0.5

--- a/p.cabal
+++ b/p.cabal
@@ -14,9 +14,10 @@ description:           A set of standard preludes for Ambiata projects. \
 
 library
   build-depends:
-                         base                        >= 4.6        && < 5
-                         , either                    >= 4.3        && < 4.5
-                       , semigroups                  == 0.16.*
+                          base                        >= 4.6        && < 5
+                        , either                      >= 4.3        && < 4.5
+                        , semigroups                  == 0.16.*
+                        , transformers                >= 0.3        && < 0.5
 
   ghc-options:
                        -Wall

--- a/src/P.hs
+++ b/src/P.hs
@@ -26,6 +26,8 @@ import           Control.Monad as X hiding (
                    , forM_
                    , msum
                    )
+import           Control.Monad.Trans.Class as X (MonadTrans(..))
+import           Control.Monad.IO.Class as X (MonadIO(..))
 import           Data.Eq as X
 import           Data.Bool as X
 import           Data.Char as X (Char)

--- a/src/P.hs
+++ b/src/P.hs
@@ -29,6 +29,7 @@ import           Control.Monad as X hiding (
 import           Control.Monad.Trans.Class as X (MonadTrans(..))
 import           Control.Monad.IO.Class as X (MonadIO(..))
 import           Data.Eq as X
+import           Data.Bifunctor as X (Bifunctor(..))
 import           Data.Bool as X
 import           Data.Char as X (Char)
 import           Data.Function as X

--- a/src/P/EitherT.hs
+++ b/src/P/EitherT.hs
@@ -1,10 +1,17 @@
 module P.EitherT (
-    firstEitherT
+    EitherT(..)
+  , eitherT
+  , bimapEitherT
+  , left
+  , hoistEither
+  , mapEitherT
+  , swapEitherT
+  , firstEitherT
   , secondEitherT
   , eitherTFromMaybe
   ) where
 
-import           Control.Applicative
+import           Control.Monad.Trans.Class ( MonadTrans(..) )
 import           Control.Monad.Trans.Either
 import           Data.Functor ()
 
@@ -12,7 +19,7 @@ firstEitherT :: (Functor m) => (e -> f) -> EitherT e m a -> EitherT f m a
 firstEitherT f = bimapEitherT f id
 
 secondEitherT :: (Functor m) => (a -> b) -> EitherT e m a -> EitherT e m b
-secondEitherT f = bimapEitherT id f
+secondEitherT = bimapEitherT id
 
-eitherTFromMaybe :: Functor m => b -> m (Maybe a) -> EitherT b m a
-eitherTFromMaybe l r = EitherT $ maybe (Left l) pure <$> r
+eitherTFromMaybe :: (Monad m) => b -> m (Maybe a) -> EitherT b m a
+eitherTFromMaybe l r = lift r >>= maybe (left l) return


### PR DESCRIPTION
This is probably going to cause a wide range of "Redundant Import" type compiler warnings (as errors) regarding `lift` and `liftIO`.

Ironically though, the more errors it causes the more its inclusion is justified probably however.....

I.e There will be a phase where we have to work to undo the work that this change will save in the future.

So yeah.