### PR TITLE
Added an applicative monoid type

### DIFF
--- a/p.cabal
+++ b/p.cabal
@@ -46,5 +46,6 @@ test-suite test
                      , either                        >= 4.3        && < 4.5
                      , mtl                           == 2.2.*
                      , QuickCheck
+                     , quickcheck-properties
                      , p
                      , transformers

--- a/src/P/Applicative.hs
+++ b/src/P/Applicative.hs
@@ -1,7 +1,9 @@
 module P.Applicative (
-    valueOrEmpty
+    ApplicativeMonoid (..)
+  , valueOrEmpty
   , emptyOrValue
   , orEmpty
+  , (<<>>)
   ) where
 
 import           Control.Applicative
@@ -16,3 +18,16 @@ emptyOrValue = valueOrEmpty . not
 
 orEmpty :: (Alternative f, Monoid a) => f a -> f a
 orEmpty f = f <|> pure mempty
+
+-- | Applicative mappend
+(<<>>) :: (Monoid a, Applicative f) => f a -> f a -> f a
+(<<>>) = liftA2 mappend
+
+-- | wrapper for monoids in an applicative context
+newtype ApplicativeMonoid m a =
+  ApplicativeMonoid { unApplicativeMonoid :: m a }
+  deriving (Show, Eq)
+
+instance (Monoid a, Applicative m) => Monoid (ApplicativeMonoid m a) where
+  mempty = ApplicativeMonoid (pure mempty)
+  mappend (ApplicativeMonoid a) (ApplicativeMonoid b) = ApplicativeMonoid (a <<>> b)

--- a/test/Test/P/Applicative.hs
+++ b/test/Test/P/Applicative.hs
@@ -1,9 +1,18 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Test.P.Applicative where
 
 import           P.Applicative
+import           Control.Applicative
 import           Data.Monoid
+import           Data.Functor.Identity
 import           Test.QuickCheck
+import           Test.QuickCheck.Property.Monoid (prop_Monoid, T(..))
+import           Test.QuickCheck.Property.Common (eq)
 
 prop_valueOrEmpty_true :: Int -> Property
 prop_valueOrEmpty_true a = valueOrEmpty True a === Just a
@@ -20,6 +29,17 @@ prop_orEmpty i =
   in
      (orEmpty (Just s) === Just s) .&&.
      (orEmpty (Nothing :: Maybe (Sum Int)) === Just (Sum 0))
+
+prop_applicative_monoid = eq $ prop_Monoid (T :: T (ApplicativeMonoid Identity (Sum Int)))
+
+instance Arbitrary a => Arbitrary (Identity a) where
+  arbitrary = Identity <$> arbitrary
+
+instance Arbitrary (m a) => Arbitrary (ApplicativeMonoid m a) where
+  arbitrary = ApplicativeMonoid <$> arbitrary
+
+instance Arbitrary a => Arbitrary (Sum a) where
+  arbitrary = Sum <$> arbitrary
 
 return []
 tests :: IO Bool


### PR DESCRIPTION
I'm not sure a about the `<<>>` operator but the mnemonics for it are:

 - outside `< >` for "applicative"
 - inside `<>` for "mappend"