### PR TITLE
Expose `undefined` and `error` with WARNING

### DIFF
--- a/src/P.hs
+++ b/src/P.hs
@@ -15,6 +15,7 @@ import           P.Monoid as X
 import           P.Ord as X
 import           P.List as X
 import           P.Function as X
+import           P.Debug as X
 import           Control.Applicative as X
 import           Control.Monad as X hiding (
                      mapM

--- a/src/P/Debug.hs
+++ b/src/P/Debug.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module P.Debug (
+  -- * Functions for development/debuggung only
+  -- | Cannot be used in production code, but might be useful
+  -- during development or debugging
+    undefined
+  , error
+  , trace
+  ) where
+
+import qualified Prelude as P
+import qualified Debug.Trace as T
+
+{-# WARNING undefined "Do not use 'undefined' in production code" #-}
+undefined :: a
+undefined = P.undefined
+
+{-# WARNING error "Do not use 'error' in production code" #-}
+error :: P.String -> a
+error = P.error
+
+{-# WARNING trace "Do not use 'trace' in production code" #-}
+trace :: P.String -> a -> a
+trace = T.trace


### PR DESCRIPTION
Will emit warning when used so will have to be removed from production code before it could be compiled