### PR TITLE
Adding ambiata prefix to project

### DIFF
--- a/p.cabal
+++ b/p.cabal
@@ -1,4 +1,4 @@
-name:                  p
+name:                  ambiata-p
 version:               0.0.1
 license:               AllRightsReserved
 author:                Ambiata <info@ambiata.com>
@@ -48,5 +48,5 @@ test-suite test
                      , mtl                           == 2.2.*
                      , QuickCheck
                      , quickcheck-properties
-                     , p
+                     , ambiata-p
                      , transformers


### PR DESCRIPTION
The beginning  of - ambiata/doc#55.
The process from here would be that anyone updating a project with this version of `p` would udpate itself and its dependencies to include the `ambiata` prefix.

Notes on updating
- Updating the project name in the `<project>.cabal` file
- Update the `Paths_<project>` to `Paths_ambiata_<project>`
- Update the dependencies of itself within the `<project>.cabal` file and/or `<project>-test.cabal` file
- Update any executables with `BuildInfo_<project>` to `BuildInfo_ambiata_<project>`

@ambiata/engineers 