### PR TITLE
Add traceM and traceIO, with warnings

### DIFF
--- a/src/P/Debug.hs
+++ b/src/P/Debug.hs
@@ -6,6 +6,8 @@ module P.Debug (
     undefined
   , error
   , trace
+  , traceM
+  , traceIO
   ) where
 
 import qualified Prelude as P
@@ -22,3 +24,11 @@ error = P.error
 {-# WARNING trace "Do not use 'trace' in production code" #-}
 trace :: P.String -> a -> a
 trace = T.trace
+
+{-# WARNING traceM "Do not use 'traceM' in production code" #-}
+traceM :: P.Monad m => P.String -> m ()
+traceM = T.traceM
+
+{-# WARNING traceIO "Do not use 'traceIO' in production code" #-}
+traceIO :: P.String -> P.IO ()
+traceIO = T.traceIO


### PR DESCRIPTION
These are useful for ordering of debug messages, and adding/removing `import Debug.Trace` gets old after a while