### PR TITLE
Remove (&) in both 7.8.4 and 7.10.2

### DIFF
--- a/src/P.hs
+++ b/src/P.hs
@@ -36,7 +36,6 @@ import           Data.Eq as X
 import           Data.Bifunctor as X (Bifunctor(..))
 import           Data.Bool as X
 import           Data.Char as X (Char)
-import           Data.Function as X
 import           Data.List as X (
                      intercalate
                    , isPrefixOf

--- a/src/P/Function.hs
+++ b/src/P/Function.hs
@@ -1,11 +1,19 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 module P.Function (
-    applyN
+    id
+  , const
+  , (.)
+  , flip
+  , ($)
+  , fix
+  , on
+  , applyN
   ) where
 
-import           Data.Int
-import           Data.List
-import           Data.Function ((.), id)
+import           Data.Int (Int)
+import           Data.List (foldr, replicate)
+import           Data.Function (id, const, (.), flip, ($))
+import           Data.Function (fix, on)
 
 applyN :: Int -> (a -> a) -> a -> a
 applyN n f =


### PR DESCRIPTION
Mismi has an `import Control.Lens ((&))` which is required for 7.8.4, but not for 7.10.2 because `(&)` is in `Data.Function` in 7.10.2