### PR TITLE
Support for GHC 8.0

### DIFF
--- a/ambiata-p.cabal
+++ b/ambiata-p.cabal
@@ -16,7 +16,7 @@ library
   build-depends:
                           base                        >= 4.6        && < 5
                         , bifunctors                  >= 4.2        && <= 5
-                        , semigroups                  == 0.16.*
+                        , semigroups                  >= 0.16       && < 0.19
 
   ghc-options:
                        -Wall
@@ -44,9 +44,8 @@ test-suite test
   ghc-options:    -Wall -threaded -O2
   hs-source-dirs: test
   build-depends:       base
-                     , either                        >= 4.3        && < 4.5
                      , mtl                           == 2.2.*
-                     , QuickCheck
+                     , QuickCheck                    >= 2.8.2      && < 2.9
                      , quickcheck-properties
                      , ambiata-p
                      , transformers

--- a/mafia
+++ b/mafia
@@ -9,24 +9,47 @@ fetch_latest () {
   fi
 }
 
+latest_version () {
+  git ls-remote https://github.com/ambiata/mafia | grep refs/heads/master | cut -f 1
+}
+
+local_version () {
+  awk '/^# Version: / { print $3; exit 0; }' $0
+}
+
 run_upgrade () {
+  MAFIA_TEMP=$(mktemp 2>/dev/null || mktemp -t 'upgrade_mafia')
+
+  clean_up () {
+    rm -f "$MAFIA_TEMP"
+  }
+
+  trap clean_up EXIT
+
+  MAFIA_CUR="$0"
+
+  if [ -L "$MAFIA_CUR" ]; then
+    echo 'Refusing to overwrite a symlink; run `upgrade` from the canonical path.' >&2
+    exit 1
+  fi
+
   echo "Checking for a new version of mafia ..."
-  fetch_latest > /tmp/mafia
+  fetch_latest > $MAFIA_TEMP
 
-  COMMIT_VERSION=$(git ls-remote https://github.com/ambiata/mafia | grep refs/heads/master | cut -f 1)
-  echo "# Version: $COMMIT_VERSION" >> /tmp/mafia
+  LATEST_VERSION=$(latest_version)
+  echo "# Version: $LATEST_VERSION" >> $MAFIA_TEMP
 
-  if ! cmp ./mafia /tmp/mafia >/dev/null 2>&1; then
+  if ! cmp $MAFIA_CUR $MAFIA_TEMP >/dev/null 2>&1; then
+    mv $MAFIA_TEMP $MAFIA_CUR
+    chmod +x $MAFIA_CUR
     echo "New version found and upgraded. You can now commit it to your git repo."
-    mv /tmp/mafia ./mafia
-    chmod +x ./mafia
   else
-    echo "You have latest mafia script"
+    echo "You have latest mafia."
   fi
 }
 
 exec_mafia () {
-  MAFIA_VERSION=$(awk '/^# Version: / { print $3; exit 0; }' $0)
+  MAFIA_VERSION=$(local_version)
 
   if [ "x$MAFIA_VERSION" = "x" ]; then
     # If we can't find the mafia version, then we need to upgrade the script.
@@ -41,7 +64,9 @@ exec_mafia () {
       # terminates. Unfortunately `mktemp` doesn't behave the same on
       # Linux and OS/X so we need to try two different approaches.
       MAFIA_TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'exec_mafia')
+
       # Create a temporary file in MAFIA_BIN so we can do an atomic copy/move dance.
+      mkdir -p $MAFIA_BIN
       MAFIA_PATH_TEMP=$(mktemp --tmpdir=$MAFIA_BIN $MAFIA_FILE-XXXXXX 2>/dev/null || TMPDIR=$MAFIA_BIN mktemp -t $MAFIA_FILE)
 
       clean_up () {
@@ -62,7 +87,6 @@ exec_mafia () {
 
         bin/bootstrap ) || exit $?
 
-      mkdir -p $(dirname $MAFIA_PATH)
       cp "$MAFIA_TEMP/mafia/.cabal-sandbox/bin/mafia" "$MAFIA_PATH_TEMP"
       chmod +x "$MAFIA_PATH_TEMP"
       mv "$MAFIA_PATH_TEMP" "$MAFIA_PATH"
@@ -83,7 +107,7 @@ else
 fi
 
 case "$MODE" in
-upgrade) shift; run_$MODE "$@" ;;
+upgrade) shift; run_upgrade "$@" ;;
 *) exec_mafia "$@"
 esac
-# Version: bb2c6e38fb23c980d4e8e3f334ca46580c19f7ae
+# Version: d64cd4f4ab42c1431752d7c84e355b7d001778f8

--- a/src/P/List.hs
+++ b/src/P/List.hs
@@ -5,7 +5,6 @@ module P.List (
   , lastMaybe
   ) where
 
-import Data.Eq
 import Data.Ord
 import Data.Function ((.))
 import Data.Functor (fmap)
@@ -19,7 +18,7 @@ import Data.Int
 -- Like `nub` from Prelude, but adds an `Ord` constraint to boost efficiency a little bit,
 -- though it could be improved even more with a Set or hashmap (with a `Hashable` constraint instead)
 -- WARNING: This is not stable due to sort
-ordNub :: (Ord a, Eq a) => [a] -> [a]
+ordNub :: Ord a => [a] -> [a]
 ordNub = fmap head . group . sort
 
 lastMaybe :: [a] -> Maybe a

--- a/test/Test/P/List.hs
+++ b/test/Test/P/List.hs
@@ -8,7 +8,7 @@ import qualified Data.List as L
 import           Test.QuickCheck
 import           Test.QuickCheck.Function
 
-prop_nub :: (Ord a, Eq a, Show a) => [a] -> Property
+prop_nub :: (Ord a, Show a) => [a] -> Property
 prop_nub a =
   (L.sort . ordNub) a === (L.sort . L.nub) a
 


### PR DESCRIPTION
Much easier than 7.10

- Needs QuickCheck 2.8.2 as that has fixes for GHC 8.0, something related to Template Haskell
- Need wider bounds for semigroups (`Data.Semigroup` is now in `base`)
- Redundant type class constraints are now a warning/error