### PR TITLE
Widen QuickCheck bounds (>= 2.7 && < 2.9) for test libraries

### DIFF
--- a/test/ambiata-p-test.cabal
+++ b/test/ambiata-p-test.cabal
@@ -6,7 +6,7 @@ build-type:            Simple
 library
   build-depends:         base
                        , ambiata-p
-                       , QuickCheck                    >= 2.8.2      && < 2.9
+                       , QuickCheck                    >= 2.7        && < 2.9
                        , quickcheck-properties
                        , transformers                  >= 0.3        && < 0.6
 


### PR DESCRIPTION
Test suites can safely be pinned down to the GHC 7.10/8.0 compatible QuickCheck (>= 2.8.2), but for libraries we want to have wider bounds so that projects downstream are not forced to upgrade.

(see also https://github.com/ambiata/disorder.hs/pull/62)