### PR TITLE
deepseq monadic bind

### DIFF
--- a/src/P/Monad.hs
+++ b/src/P/Monad.hs
@@ -40,6 +40,7 @@ module P.Monad (
   -- * Strict monadic functions
   , (<$!>)
   , (>>=!!)
+  , (>>=!)
 
   -- * Extensions
   , bind
@@ -81,6 +82,11 @@ infixl 1 >>=!!
 (>>=!!) :: (NFData a, Monad m) => m a -> (a -> m b) -> m b
 (>>=!!) m f = m >>= f . force
 {-# INLINE (>>=!!) #-}
+
+-- | Seq version 'Control.Monad.>>='
+(>>=!) :: (Monad m) => m a -> (a -> m b) -> m b
+(>>=!) m f = m >>= f . (\x -> x `seq` x)
+{-# INLINE (>>=!) #-}
 
 -- | Identifier version of 'Control.Monad.=<<'.
 bind :: Monad m => (a -> m b) -> m a -> m b

--- a/src/P/Monad.hs
+++ b/src/P/Monad.hs
@@ -39,6 +39,7 @@ module P.Monad (
 
   -- * Strict monadic functions
   , (<$!>)
+  , (>>=!!)
 
   -- * Extensions
   , bind
@@ -53,7 +54,8 @@ import           Control.Monad (foldM, foldM_, replicateM, replicateM_)
 import           Control.Monad (guard, when, unless)
 import           Control.Monad (liftM, liftM2, liftM3, liftM4, liftM5, ap)
 
-import           Prelude (seq)
+import           Control.DeepSeq (NFData, force)
+import           Prelude (seq, (.))
 
 #if (__GLASGOW_HASKELL__ >= 710)
 
@@ -72,6 +74,13 @@ f <$!> m = do
 {-# INLINE (<$!>) #-}
 
 #endif
+
+infixl 1 >>=!!
+
+-- | Deepseq version 'Control.Monad.>>='
+(>>=!!) :: (NFData a, Monad m) => m a -> (a -> m b) -> m b
+(>>=!!) m f = m >>= f . force
+{-# INLINE (>>=!!) #-}
 
 -- | Identifier version of 'Control.Monad.=<<'.
 bind :: Monad m => (a -> m b) -> m a -> m b


### PR DESCRIPTION
Like `(>>=)` but evaluates the `a` to normal form. Since `(>>=)` is unchanged, `do` blocks will still be the same.