### PR TITLE
Add valueOrEmpty'

### DIFF
--- a/src/P/Applicative.hs
+++ b/src/P/Applicative.hs
@@ -1,7 +1,9 @@
 module P.Applicative (
     ApplicativeMonoid (..)
   , valueOrEmpty
+  , valueOrEmpty'
   , emptyOrValue
+  , emptyOrValue'
   , orEmpty
   , eitherA
   , (<<>>)
@@ -16,6 +18,12 @@ valueOrEmpty b a = if b then pure a else empty
 
 emptyOrValue :: Alternative f => Bool -> a -> f a
 emptyOrValue = valueOrEmpty . not
+
+valueOrEmpty' :: Alternative f => Bool -> f a -> f a
+valueOrEmpty' b f = if b then f else empty
+
+emptyOrValue' :: Alternative f => Bool -> f a -> f a
+emptyOrValue' = valueOrEmpty' . not
 
 orEmpty :: (Alternative f, Monoid a) => f a -> f a
 orEmpty f = f <|> pure mempty


### PR DESCRIPTION
```
λ> valueOrZero False (Just 'a')
<interactive>:4:1:
    No instance for (Monoid Char) arising from a use of ‘valueOrZero’

λ> valueOrEmpty False (Just 'a')
*** Exception: user error (mzero)

λ> valueOrEmpty' False (Just 'a')
Nothing
```

Does this belong in p, or is there something out there for it already?

@jystic @charleso @olorin 