### PR TITLE
'ordNub' is now stable and lazy

### DIFF
--- a/ambiata-p.cabal
+++ b/ambiata-p.cabal
@@ -15,8 +15,9 @@ description:           A set of standard preludes for Ambiata projects. \
 library
   build-depends:
                           base                        >= 4.6        && < 5
-                        , bifunctors                  >= 4.2        && <= 5.3
-                        , deepseq                     >= 1.3        && <= 1.5
+                        , bifunctors                  >= 4.2        && < 5.4
+                        , containers                  >= 0.4        && < 0.6
+                        , deepseq                     >= 1.3        && < 1.5
                         , semigroups                  >= 0.16       && < 0.19
                         , text                        >= 1.1        && < 1.3
                         , transformers                >= 0.4        && < 0.6

--- a/src/P/List.hs
+++ b/src/P/List.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 module P.List (
     count
@@ -5,21 +6,38 @@ module P.List (
   , lastMaybe
   ) where
 
-import Data.Ord
-import Data.Function ((.))
-import Data.Functor (fmap)
-import Data.List hiding (head, group)
-import Data.List.NonEmpty (head, group)
-import Data.Maybe (Maybe, listToMaybe)
-import Data.Bool
-import Data.Int
+import           Data.Bool (Bool)
+import           Data.Function ((.))
+import           Data.Int (Int)
+import           Data.List (reverse, length, filter)
+import           Data.List.NonEmpty ()
+import           Data.Maybe (Maybe, listToMaybe)
+import           Data.Ord (Ord)
+import qualified Data.Set as Set
 
--- |
--- Like `nub` from Prelude, but adds an `Ord` constraint to boost efficiency a little bit,
--- though it could be improved even more with a Set or hashmap (with a `Hashable` constraint instead)
--- WARNING: This is not stable due to sort
+-- | /O(n log n)/ Remove duplicate elements from a list.
+--
+--   Unlike 'Data.List.nub', this version requires 'Ord' and runs in
+--   /O(n log n)/ instead of /O(n²)/.
+--
+--   > ordNub "foo bar baz" == "fo barz"
+--   > ordNub [3,2,1,2,1] == [3,2,1]
+--   > List.take 3 (ordNub [4,5,6,undefined]) == [4,5,6]
+--   > ordNub xs == List.nub xs
+--
 ordNub :: Ord a => [a] -> [a]
-ordNub = fmap head . group . sort
+ordNub =
+  let
+    loop seen = \case
+      [] ->
+        []
+      x : xs ->
+        if Set.member x seen then
+          loop seen xs
+        else
+          x : loop (Set.insert x seen) xs
+  in
+    loop Set.empty
 
 lastMaybe :: [a] -> Maybe a
 lastMaybe = listToMaybe . reverse

--- a/test/Test/P/List.hs
+++ b/test/Test/P/List.hs
@@ -10,7 +10,7 @@ import           Test.QuickCheck.Function
 
 prop_nub :: (Ord a, Show a) => [a] -> Property
 prop_nub a =
-  (L.sort . ordNub) a === (L.sort . L.nub) a
+  ordNub a === L.nub a
 
 prop_lastMaybe :: (Eq a, Show a) => a -> [a] -> Property
 prop_lastMaybe a l =


### PR DESCRIPTION
New implementation of `ordNub` which produces elements in their original order and is also lazy.

These two things are important for some QuickCheck stuff I'm doing where I want to filter out duplicate shrinks.

It requires a dependency on containers which we already have transitively via `bifunctors`.

/cc @nhibberd @markhibberd @charleso 