### PR TITLE
Add mcase and ecase

### DIFF
--- a/src/P/Either.hs
+++ b/src/P/Either.hs
@@ -3,6 +3,7 @@ module P.Either (
   , maybeToRight
   , leftToMaybe
   , rightToMaybe
+  , ecase
   ) where
 
 maybeToLeft :: r -> Maybe l -> Either l r
@@ -16,3 +17,6 @@ leftToMaybe = either Just (const Nothing)
 
 rightToMaybe :: Either l r -> Maybe r
 rightToMaybe = either (const Nothing) Just
+
+ecase :: Either l r -> (l -> b) -> (r -> b) -> b
+ecase e l = flip (either l) e

--- a/src/P/Maybe.hs
+++ b/src/P/Maybe.hs
@@ -2,6 +2,8 @@ module P.Maybe (
     fromMaybeM
   , lazyMaybe'
   , strictMaybe
+  , mcase
+  , mcase'
   ) where
 
 import           Control.Applicative
@@ -13,7 +15,6 @@ import           Prelude
 fromMaybeM :: Applicative f => f a -> Maybe a -> f a
 fromMaybeM = flip maybe pure
 
-
 strictMaybe :: Maybe a -> Maybe' a
 strictMaybe Nothing = Nothing'
 strictMaybe (Just x) = Just' x
@@ -21,3 +22,9 @@ strictMaybe (Just x) = Just' x
 lazyMaybe' :: Maybe' a -> Maybe a
 lazyMaybe' Nothing' = Nothing
 lazyMaybe' (Just' x) = Just x
+
+mcase :: Maybe a -> b -> (a -> b) -> b
+mcase m b = flip (maybe b) m
+
+mcase' :: Maybe' a -> b -> (a -> b) -> b
+mcase' m b = flip (maybe' b) m


### PR DESCRIPTION
When using Maybe and Either for control flow, you usually have a simple error-handling case for Nothing or Left, and a fairly large continuation for Just / Right. `either` and `maybe` force you to wrap it all up in parens and indent it strangely. `mcase` and `ecase` are the handy flipped version, the `for` to their `traverse`.

```haskell
either
  (T.putStrLn . renderError)
  (\a -> do
    gnarly do block
    extra parens for you)
  var
```

```haskell
ecase var (T.putStrLn . renderError) $ do
  a nice do block
  for nice people
```