### PR TITLE
Export Bitraversable functions which were moved out from the class in 5.x

### DIFF
--- a/src/P.hs
+++ b/src/P.hs
@@ -53,6 +53,8 @@ import           Data.Bitraversable as X (
                      Bitraversable (..)
                    , bisequenceA
                    , bifor
+                   , bisequence
+                   , bimapM
                    )
 import           Data.Bifoldable as X (
                      Bifoldable (..)


### PR DESCRIPTION
! @olorin @jystic 

http://hackage.haskell.org/package/bifunctors-4.2.1/docs/Data-Bitraversable.html#v:bisequence

http://hackage.haskell.org/package/bifunctors-5.4.1/docs/Data-Bitraversable.html#v:bisequence