### PR TITLE
Add double fmap operator

### DIFF
--- a/src/P/Functor.hs
+++ b/src/P/Functor.hs
@@ -2,11 +2,17 @@
 module P.Functor (
     module X
   , with
+  , (<$$>)
   ) where
 
 import           Data.Functor as X (Functor(..), ($>), (<$>), void)
+import           Data.Function((.))
 
 with :: Functor f => f a -> (a -> b) -> f b
 with xs f =
   fmap f xs
 {-# INLINE with #-}
+
+(<$$>) :: (Functor g, Functor f) => (a -> b) -> f (g a) -> f (g b)
+(<$$>) = fmap . fmap
+{-# INLINE (<$$>) #-}

--- a/src/P/Functor.hs
+++ b/src/P/Functor.hs
@@ -3,6 +3,7 @@ module P.Functor (
     module X
   , with
   , (<$$>)
+  , fmap2
   ) where
 
 import           Data.Functor as X (Functor(..), ($>), (<$>), void)
@@ -16,3 +17,7 @@ with xs f =
 (<$$>) :: (Functor g, Functor f) => (a -> b) -> f (g a) -> f (g b)
 (<$$>) = fmap . fmap
 {-# INLINE (<$$>) #-}
+
+fmap2 :: (Functor g, Functor f) => (a -> b) -> f (g a) -> f (g b)
+fmap2 = fmap . fmap
+{-# INLINE fmap2 #-}


### PR DESCRIPTION
Pros:
* `fmap f <$> whatever` can now be written as `f <$$> whatever`.

Cons:
* Do we really want to add another function/operator to `P`?
* The name clashes with something in the `wl-print`package, but anyone using that package should be using qualified or explicit imports.

! @markhibberd @jystic @charleso 
/jury approve @charleso @ambiata-ci