### PR TITLE
Add function sortNub, nub with sorted output

### DIFF
--- a/src/P/List.hs
+++ b/src/P/List.hs
@@ -3,6 +3,7 @@
 module P.List (
     count
   , ordNub
+  , sortNub
   , lastMaybe
   ) where
 
@@ -18,7 +19,9 @@ import qualified Data.Set as Set
 -- | /O(n log n)/ Remove duplicate elements from a list.
 --
 --   Unlike 'Data.List.nub', this version requires 'Ord' and runs in
---   /O(n log n)/ instead of /O(n²)/.
+--   /O(n log n)/ instead of /O(n²)/. Like 'Data.List.nub' the output
+--   order is identical to the input order.
+--   See 'sortNub' for `nub` behaviour with sorted output.
 --
 --   > ordNub "foo bar baz" == "fo barz"
 --   > ordNub [3,2,1,2,1] == [3,2,1]
@@ -38,6 +41,19 @@ ordNub =
           x : loop (Set.insert x seen) xs
   in
     loop Set.empty
+
+-- | /O(n log n)/ Sort and remove duplicate elements from a list.
+--
+--   Unlike 'Data.List.nub', this version requires 'Ord' and runs in
+--   /O(n log n)/ instead of /O(n²)/. The output list is returned in
+--   sorted order.
+--
+--   > sortNub [3,2,1,2,1] == [1,2,3]
+--   > sortNub xs == List.sort (List.nub xs)
+--
+sortNub :: Ord a => [a] -> [a]
+sortNub = Set.toList . Set.fromList
+
 
 lastMaybe :: [a] -> Maybe a
 lastMaybe = listToMaybe . reverse

--- a/test/Test/P/List.hs
+++ b/test/Test/P/List.hs
@@ -8,9 +8,14 @@ import qualified Data.List as L
 import           Test.QuickCheck
 import           Test.QuickCheck.Function
 
-prop_nub :: (Ord a, Show a) => [a] -> Property
-prop_nub a =
+prop_ordNub :: (Ord a, Show a) => [a] -> Property
+prop_ordNub a =
   ordNub a === L.nub a
+
+prop_sortNub :: (Ord a, Show a) => [a] -> Property
+prop_sortNub a =
+  sortNub a === L.sort (L.nub a)
+
 
 prop_lastMaybe :: (Eq a, Show a) => a -> [a] -> Property
 prop_lastMaybe a l =


### PR DESCRIPTION
In commit a86144bad6 the behavior of `ordNub` changed so that the
output after removal of duplicated is no longer sorted. The new
behavior is correct, but some software was relying on the old
behavior. Code that depends on the output being sorted can switch
to use this new function.

! @jystic @tmcgilchrist @nhibberd @charleso @thumphries 