### PR TITLE
ordNubBy :: (a -> a -> Ordering) -> [a] -> [a]

### DIFF
--- a/test/Test/P/List.hs
+++ b/test/Test/P/List.hs
@@ -3,7 +3,9 @@ module Test.P.List where
 
 import           P.List
 
+import           Data.Function (on)
 import qualified Data.List as L
+import           Data.Ord (comparing)
 
 import           Test.QuickCheck
 import           Test.QuickCheck.Function
@@ -12,10 +14,13 @@ prop_ordNub :: (Ord a, Show a) => [a] -> Property
 prop_ordNub a =
   ordNub a === L.nub a
 
+prop_ordNubBy :: (Ord a, Show a) => [[a]] -> Property
+prop_ordNubBy a =
+  ordNubBy (comparing length) a === L.nubBy ((==) `on` length) a
+
 prop_sortNub :: (Ord a, Show a) => [a] -> Property
 prop_sortNub a =
   sortNub a === L.sort (L.nub a)
-
 
 prop_lastMaybe :: (Eq a, Show a) => a -> [a] -> Property
 prop_lastMaybe a l =


### PR DESCRIPTION
This adds `ordNubBy` where a custom comparison function can be supplied.

Usage:
```hs
ordNubBy (comparing length) ["foo","bar","quux"] == ["foo","quux"]
ordNubBy (comparing fst) [("foo", 10),("foo", 20),("bar", 30)] == [("foo", 10),("bar", 30)]
```

! @nhibberd @erikd-ambiata
/jury approved @erikd-ambiata @nhibberd